### PR TITLE
Added option for navy blue for title/end slides

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,7 +2,7 @@ Except where otherwise stated, this code is:
 
 MIT License
 
-Copyright (c) 2023-2024 Isaac Ren
+Copyright (c) 2023 Isaac Ren
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ The following options are available when loading the theme:
   absolute) to the Figtree font files. The path used on Overleaf is provided
   in `sample.tex`. For local setups, use the option `auto` when `fontspec` can
   find the font by itself.
+- `navy=<true|false>` Choose if wanting to use navy blue for the title and end slides or to use the light blue for title and KTH blue for end. Defaults as true.

--- a/beamerthemekthpq.sty
+++ b/beamerthemekthpq.sty
@@ -1,4 +1,4 @@
-% Copyright (c) 2023-2024 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
+% Copyright (c) 2023 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
 
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{beamerthemekthpq}[2023/10/05]
@@ -7,6 +7,17 @@
 
 % Settings
 \DeclareOption*{\PassOptionsToPackage{\CurrentOption}{kthpq-files/beamerfontthemekthpq}}
+\SetupKeyvalOptions{%
+family=kthpq,
+prefix=kthpq@
+}
+
+\DeclareOption{navy}{\PassOptionsToPackage{\CurrentOption}{kthpq-files/beamercolorthemekthpq}
+\PassOptionsToPackage{\CurrentOption}{kthpq-files/beamerinnerthemekthpq.sty}}
+\SetupKeyvalOptions{%
+family=kthpq,
+prefix=kthpq@
+}
 
 \ProcessOptions\relax
 

--- a/beamerthemekthpq.sty
+++ b/beamerthemekthpq.sty
@@ -1,4 +1,4 @@
-% Copyright (c) 2023 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
+% Copyright (c) 2023-2024 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
 
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{beamerthemekthpq}[2023/10/05]

--- a/kthpq-files/beamercolorthemekthpq.sty
+++ b/kthpq-files/beamercolorthemekthpq.sty
@@ -1,9 +1,16 @@
-% Copyright (c) 2023-2024 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
+% Copyright (c) 2023 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
 
 \NeedsTeXFormat{LaTeX2e}
 \mode<presentation>
 
 \RequirePackage{xcolor}
+\RequirePackage{kvoptions}
+
+\SetupKeyvalOptions{%
+family=kthpq,
+prefix=kthpq@
+}
+
 
 % COLORS
 % Primary colors
@@ -76,11 +83,18 @@
 
 \setbeamercolor{titlelike}{parent=palette primary}
 
-\setbeamercolor{title}{bg=light blue, fg=navy}
+\ifkthpq@navy
+    \setbeamercolor{title}{bg=navy, fg=white}
+\else
+    \setbeamercolor{title}{bg=light blue, fg=navy}
+\fi
 % \setbeamercolor{title in head/foot}{parent=palette quaternary}
 % \setbeamercolor{title in sidebar}{parent=palette sidebar quaternary}
 
-\setbeamercolor{subtitle}{fg=KTH blue}
+\ifkthpq@navy
+	\setbeamercolor{subtitle}{fg=sky blue}
+\else
+	\setbeamercolor{subtitle}{fg=KTH blue}
 
 \setbeamercolor{author}{parent=subtitle}
 % \setbeamercolor{author in head/foot}{parent=palette primary}

--- a/kthpq-files/beamercolorthemekthpq.sty
+++ b/kthpq-files/beamercolorthemekthpq.sty
@@ -1,4 +1,4 @@
-% Copyright (c) 2023 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
+% Copyright (c) 2023-2024 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
 
 \NeedsTeXFormat{LaTeX2e}
 \mode<presentation>

--- a/kthpq-files/beamerfontthemekthpq.sty
+++ b/kthpq-files/beamerfontthemekthpq.sty
@@ -1,4 +1,4 @@
-% Copyright (c) 2023 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
+% Copyright (c) 2023-2024 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
 
 \mode<presentation>
 
@@ -58,13 +58,19 @@ BoldItalicFont = *-BoldItalic%
 %
 % Italic numerals are not included.
 \RequirePackage[warnings-off={mathtools-colon, mathtools-overbracket}]{unicode-math}
-\RequirePackage{firamath-otf}
+\setmathfont{Latin Modern Math}
+% Use Fira Math where it is defined (except for circle binary operations and
+% symbols defined in Figtree). See Fira Math's documentation for details.
+\setmathfont{Fira Math}[range={"2190-"2211,"2213-"2214,"2217-"2230,"2234-"2259,"2261-"2263,"2266-"223D,"2240-"224C,"2250-"2255,"2260-"226B,"226E-"2294,"22C5,"22CD-"22CF,"22D6-"22E8,"22EF,"2302,"2308-"230B,"2310,"239B-"23AD,"23B4-"23B5,"23DC-"23DF,"27C2,"27E8-"27EB,"27EE-"27FF,"2900-"290B,"2912-"291C,"294A-"2951,"295A-"2961,"296E-"296F,"2980-"2981,"299F-"29A3,"29A6-"29A7,"2980,"29A0C,"2A7D-"2A7E,"2B30-"2B36,"2B39-"2B3D,"2B45-"2B46}]
 \ifautofontdir
+\setmathfont{Figtree-Regular}[range={"0021-"036F,"2010-"205E,"215B-"215E,\minus,%see https://github.com/wspr/unicode-math/issues/626
+"2212,"2215,"2260,"2264-"2265}]
 \setmathfont{Figtree-Regular}[range=up/{latin,Latin,num}]
 \setmathfont{Figtree-Italic}[range=it/{latin,Latin}]
 \setmathfont{Figtree-Bold}[range=bfup/{latin,Latin,num}]
 \setmathfont{Figtree-BoldItalic}[range=bfit/{latin,Latin}]
 \else
+\setmathfont{Figtree-Regular}[Path=\kthpq@fontdir,range={"0021-"036F,"2010-"205E,"215B-"215E,\minus,"2212,"2215,"2260,"2264-"2265}]
 \setmathfont{Figtree-Regular}[Path=\kthpq@fontdir,range=up/{latin,Latin,num}]
 \setmathfont{Figtree-Italic}[Path=\kthpq@fontdir,range=it/{latin,Latin}]
 \setmathfont{Figtree-Bold}[Path=\kthpq@fontdir,range=bfup/{latin,Latin,num}]
@@ -74,8 +80,8 @@ BoldItalicFont = *-BoldItalic%
 \setmathfont{Arial Italic}[range=it/{greek,Greek}]
 \setmathfont{Arial Bold}[range=bfup/{greek,Greek}]
 \setmathfont{Arial Bold Italic}[range=bfit/{greek,Greek}]
-\setmathfont{Latin Modern Math}[range={frak,\bigcap,\bigcup,\bigoplus,\bigwedge,\bigvee}]
-\DeclareMathAlphabet{\mathcal}{OMS}{cmsy}{m}{n}
+\DeclareSymbolFont{symbols}{OMS}{cmsy}{m}{n}
+\DeclareSymbolFontAlphabet{\mathcal}{symbols}
 \setoperatorfont\mathsf
 \else
 % Set operators to sans with sans math fonts, and then all letters and text

--- a/kthpq-files/beamerfontthemekthpq.sty
+++ b/kthpq-files/beamerfontthemekthpq.sty
@@ -1,4 +1,4 @@
-% Copyright (c) 2023-2024 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
+% Copyright (c) 2023 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
 
 \mode<presentation>
 
@@ -12,6 +12,7 @@ prefix=kthpq@
 \DeclareStringOption[lualatex]{engine}
 \DeclareStringOption[sf]{mathshape}
 \DeclareStringOption[auto]{fontdir}
+\DeclareBoolOption[true]{navy}
 \ProcessKeyvalOptions{kthpq}
 
 % Post-processing of options
@@ -57,19 +58,13 @@ BoldItalicFont = *-BoldItalic%
 %
 % Italic numerals are not included.
 \RequirePackage[warnings-off={mathtools-colon, mathtools-overbracket}]{unicode-math}
-\setmathfont{Latin Modern Math}
-% Use Fira Math where it is defined (except for circle binary operations and
-% symbols defined in Figtree). See Fira Math's documentation for details.
-\setmathfont{Fira Math}[range={"2190-"2211,"2213-"2214,"2217-"2230,"2234-"2259,"2261-"2263,"2266-"223D,"2240-"224C,"2250-"2255,"2260-"226B,"226E-"2294,"22C5,"22CD-"22CF,"22D6-"22E8,"22EF,"2302,"2308-"230B,"2310,"239B-"23AD,"23B4-"23B5,"23DC-"23DF,"27C2,"27E8-"27EB,"27EE-"27FF,"2900-"290B,"2912-"291C,"294A-"2951,"295A-"2961,"296E-"296F,"2980-"2981,"299F-"29A3,"29A6-"29A7,"2980,"29A0C,"2A7D-"2A7E,"2B30-"2B36,"2B39-"2B3D,"2B45-"2B46}]
+\RequirePackage{firamath-otf}
 \ifautofontdir
-\setmathfont{Figtree-Regular}[range={"0021-"036F,"2010-"205E,"215B-"215E,\minus,%see https://github.com/wspr/unicode-math/issues/626
-"2212,"2215,"2260,"2264-"2265}]
 \setmathfont{Figtree-Regular}[range=up/{latin,Latin,num}]
 \setmathfont{Figtree-Italic}[range=it/{latin,Latin}]
 \setmathfont{Figtree-Bold}[range=bfup/{latin,Latin,num}]
 \setmathfont{Figtree-BoldItalic}[range=bfit/{latin,Latin}]
 \else
-\setmathfont{Figtree-Regular}[Path=\kthpq@fontdir,range={"0021-"036F,"2010-"205E,"215B-"215E,\minus,"2212,"2215,"2260,"2264-"2265}]
 \setmathfont{Figtree-Regular}[Path=\kthpq@fontdir,range=up/{latin,Latin,num}]
 \setmathfont{Figtree-Italic}[Path=\kthpq@fontdir,range=it/{latin,Latin}]
 \setmathfont{Figtree-Bold}[Path=\kthpq@fontdir,range=bfup/{latin,Latin,num}]
@@ -79,8 +74,8 @@ BoldItalicFont = *-BoldItalic%
 \setmathfont{Arial Italic}[range=it/{greek,Greek}]
 \setmathfont{Arial Bold}[range=bfup/{greek,Greek}]
 \setmathfont{Arial Bold Italic}[range=bfit/{greek,Greek}]
-\DeclareSymbolFont{symbols}{OMS}{cmsy}{m}{n}
-\DeclareSymbolFontAlphabet{\mathcal}{symbols}
+\setmathfont{Latin Modern Math}[range={frak,\bigcap,\bigcup,\bigoplus,\bigwedge,\bigvee}]
+\DeclareMathAlphabet{\mathcal}{OMS}{cmsy}{m}{n}
 \setoperatorfont\mathsf
 \else
 % Set operators to sans with sans math fonts, and then all letters and text

--- a/kthpq-files/beamerinnerthemekthpq.sty
+++ b/kthpq-files/beamerinnerthemekthpq.sty
@@ -1,4 +1,4 @@
-% Copyright (c) 2023-2024 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
+% Copyright (c) 2023 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
 
 \NeedsTeXFormat{LaTeX2e}
 \mode<presentation>
@@ -9,6 +9,14 @@
 \RequirePackage{adjustbox}
 
 \graphicspath{ {kthpq-files/figs/} }
+
+\RequirePackage{kvoptions}
+
+\SetupKeyvalOptions{%
+family=kthpq,
+prefix=kthpq@
+}
+
 
 % INNER THEME
 % title, parts, blocks, etc.
@@ -28,7 +36,11 @@
 % is specified by the color theme.
 \def\linesfilename{}
 
-\def\titlelogofilename{logo/KTH_logo_RGB_bla.pdf}
+\ifkthpq@navy
+    \def\titlelogofilename{logo/KTH_logo_RGB_vit.pdf}
+\else 
+    \def\titlelogofilename{logo/KTH_logo_RGB_bla.pdf}
+\fi
 \def\titlelinesfilename{lines/Linjemonster_himmelsbla_RGB_1x1.pdf}
 \def\sectionlinesfilename{lines/Linjemonster_himmelsbla_RGB_1x1.pdf}
 \def\bodylinesfilename{lines/Linjemonster_himmelsbla_RGB_1x1.pdf}
@@ -107,7 +119,11 @@
 \newcommand*{\insertendpage}{%
 \setbeamertemplate{headline}{}
 \setbeamertemplate{footline}{}
-\setbeamercolor{background canvas}{bg=KTH blue}
+\ifkthpq@navy
+    \setbeamercolor{background canvas}{bg=navy}
+\else 
+    \setbeamercolor{background canvas}{bg=KTH blue}
+\fi
 \begin{frame}[b]
 \let\linesfilename\titlelinesfilename
 \begin{tikzpicture}[remember picture, overlay]

--- a/kthpq-files/beamerinnerthemekthpq.sty
+++ b/kthpq-files/beamerinnerthemekthpq.sty
@@ -1,4 +1,4 @@
-% Copyright (c) 2023 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
+% Copyright (c) 2023-2024 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
 
 \NeedsTeXFormat{LaTeX2e}
 \mode<presentation>

--- a/kthpq-files/beamerouterthemekthpq.sty
+++ b/kthpq-files/beamerouterthemekthpq.sty
@@ -1,4 +1,4 @@
-% Copyright (c) 2023-2024 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
+% Copyright (c) 2023 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
 
 \NeedsTeXFormat{LaTeX2e}
 \mode<presentation>

--- a/kthpq-files/beamerouterthemekthpq.sty
+++ b/kthpq-files/beamerouterthemekthpq.sty
@@ -1,4 +1,4 @@
-% Copyright (c) 2023 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
+% Copyright (c) 2023-2024 Isaac Ren. Licensed under the MIT license (see LICENSE.txt).
 
 \NeedsTeXFormat{LaTeX2e}
 \mode<presentation>


### PR DESCRIPTION
Hi!
Thank you for putting this together. Fellow KTH person here. I happen to like a lot the navy blue variations of the theme so I added a boolean flag in the \usetheme to have navy backgrounds in the title and end slides and updates the font colors in the title accordingly. At the moment it's set as default but of course you can change that if you want. I also added it in the README. If you're interested feel free to merge it otherwise I'll just keep it in my fork :) Thank you again for the work you've put in this!

Francesco